### PR TITLE
Fix error message after image retry

### DIFF
--- a/supabase/functions/process_dream/index.ts
+++ b/supabase/functions/process_dream/index.ts
@@ -220,11 +220,13 @@ serve(async (req) => {
 
     // Error handling for DALL-E
     let imageRes = await imageReq();
+    let txt: string | undefined;
     if (!imageRes.ok) {
-      const txt = await imageRes.text();
+      txt = await imageRes.text();
       if (txt.includes("image_generation_user_error")) {
         await new Promise((r) => setTimeout(r, 1200));
         imageRes = await imageReq();
+        if (!imageRes.ok) txt = await imageRes.text();
       }
       if (!imageRes.ok) {
         console.error("Image API:", txt);


### PR DESCRIPTION
## Summary
- retrying image generation would return the wrong error text
- update retry logic to refresh error string when a retry occurs

## Testing
- `npx --yes tsc --noEmit supabase/functions/process_dream/index.ts` *(fails: Cannot find module 'https://deno.land/std/http/server.ts')*

------
https://chatgpt.com/codex/tasks/task_e_6841e6d67184832fb7aa4589bf1d7c94