### PR TITLE
Add shared Supabase config

### DIFF
--- a/mobile/config.ts
+++ b/mobile/config.ts
@@ -1,0 +1,11 @@
+export const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL ?? "";
+export const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? "";
+
+const projectRef = process.env.SUPABASE_PROJECT_REF ??
+  SUPABASE_URL.match(/^https:\/\/([a-z0-9-]+)\.supabase\.co/i)?.[1];
+
+export const FUNCTIONS_BASE_URL = projectRef
+  ? `https://${projectRef}.functions.supabase.co`
+  : "";
+
+export const PROCESS_DREAM_URL = `${FUNCTIONS_BASE_URL}/process_dream`;

--- a/mobile/screens/RecordScreen.tsx
+++ b/mobile/screens/RecordScreen.tsx
@@ -7,6 +7,7 @@ import { Header } from "../components/Header";
 import { StatusText } from "../components/StatusText";
 import { RecorderCircle } from "../components/RecorderCircle";
 import { Controls } from "../components/Controls";
+import { PROCESS_DREAM_URL } from "../config";
 
 export default function RecordScreen() {
   const audioRecorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
@@ -112,17 +113,14 @@ export default function RecordScreen() {
         console.log(pair[0], pair[1]);
       }
 
-      const res = await fetch(
-        "https://lzrhocmfiulykdxjzaku.functions.supabase.co/process_dream",
-        {
+      const res = await fetch(PROCESS_DREAM_URL, {
           method: "POST",
           headers: {
             Accept: "application/json",
             "Content-Type": "multipart/form-data",
           },
           body: formData,
-        }
-      );
+        });
 
       const result = await res.text();
       console.log("Server response:", result);


### PR DESCRIPTION
## Summary
- centralize Supabase settings in `mobile/config.ts`
- use the shared config for the upload endpoint in `RecordScreen`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f4d5a5df4832fbcb90afe5dcd2815