### PR TITLE
Refactor ShinyGradientButton into reusable component

### DIFF
--- a/mobile/components/ShinyGradientButton.tsx
+++ b/mobile/components/ShinyGradientButton.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useRef } from "react";
+import {
+  Pressable,
+  Text,
+  StyleSheet,
+  Animated,
+  Easing,
+} from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+
+interface ButtonProps {
+  onPress: () => void;
+  children: React.ReactNode;
+}
+
+/**
+ * ShinyGradientButton — CTA with a subtle, slow shimmer + press feedback.
+ */
+export const ShinyGradientButton: React.FC<ButtonProps> = ({
+  onPress,
+  children,
+}) => {
+  // Animated value that sweeps from 0 ➔ 1 continuously
+  const shimmer = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.timing(shimmer, {
+        toValue: 1,
+        duration: 4000, // slower sweep
+        easing: Easing.linear,
+        useNativeDriver: true,
+      }),
+      { resetBeforeIteration: true }
+    );
+
+    loop.start();
+    return () => loop.stop();
+  }, [shimmer]);
+
+  // Translate the shimmer bar across ~150% of the button width so the reset is off-screen
+  const translateX = shimmer.interpolate({
+    inputRange: [0, 1],
+    outputRange: [-350, 350],
+  });
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.buttonWrapper,
+        pressed && { transform: [{ scale: 0.97 }] },
+      ]}
+      android_ripple={{ color: "#ffffff20" }}
+    >
+      <LinearGradient colors={["#00EAFF", "#FF4EE0"]} style={styles.buttonInner}>
+        <Text style={styles.buttonText}>{children}</Text>
+
+        {/* Shimmer overlay – dimmer white and wider bar */}
+        <Animated.View
+          pointerEvents="none"
+          style={[styles.shimmerBar, { transform: [{ translateX }] }]}
+        >
+          <LinearGradient
+            // dimmed highlight
+            colors={["transparent", "rgba(255,255,255,0.25)", "transparent"]}
+            start={{ x: 0, y: 0.5 }}
+            end={{ x: 1, y: 0.5 }}
+            style={{ flex: 1 }}
+          />
+        </Animated.View>
+      </LinearGradient>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  buttonWrapper: {
+    width: "100%",
+    borderRadius: 20,
+    overflow: "hidden",
+    elevation: 4,
+  },
+  buttonInner: {
+    height: 70,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  buttonText: {
+    fontSize: 22,
+    fontWeight: "600",
+    color: "#FFFFFF",
+  },
+  shimmerBar: {
+    ...StyleSheet.absoluteFillObject,
+    width: "200%", // make the bar wider than the button for smoother reset
+  },
+});

--- a/mobile/screens/home/ComicResultScreen.tsx
+++ b/mobile/screens/home/ComicResultScreen.tsx
@@ -11,7 +11,7 @@ import {
 import { LinearGradient } from "expo-linear-gradient";
 import { useNavigation } from "@react-navigation/native";
 import { Heart, Share2, Download, X } from "lucide-react-native";
-import { ShinyGradientButton } from "../onboarding/WelcomeScreen";
+import { ShinyGradientButton } from "../../components/ShinyGradientButton";
 
 // dummy 6‑panel placeholders (swap uri for your real images)
 const PANELS = [1, 2, 3, 4, 5, 6].map((n) => ({

--- a/mobile/screens/home/DashboardScreen.tsx
+++ b/mobile/screens/home/DashboardScreen.tsx
@@ -13,7 +13,7 @@ import { useNavigation } from "@react-navigation/native";
 import { Home, Book, Settings } from "lucide-react-native";
 
 // reuse gradient button from WelcomeScreen (move to components/ later)
-import { ShinyGradientButton } from "../onboarding/WelcomeScreen";
+import { ShinyGradientButton } from "../../components/ShinyGradientButton";
 
 const DashboardScreen: React.FC = () => {
   const navigation = useNavigation();

--- a/mobile/screens/home/RecordScreen.tsx
+++ b/mobile/screens/home/RecordScreen.tsx
@@ -11,7 +11,7 @@ import { LinearGradient } from "expo-linear-gradient";
 import { useAudioRecorder, AudioModule, RecordingPresets } from "expo-audio";
 import { useNavigation } from "@react-navigation/native";
 import { ChevronLeft } from "lucide-react-native";
-import { ShinyGradientButton } from "../onboarding/WelcomeScreen";
+import { ShinyGradientButton } from "../../components/ShinyGradientButton";
 import { RootStackParamList } from "../../App";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 

--- a/mobile/screens/onboarding/CreateAccountScreen.tsx
+++ b/mobile/screens/onboarding/CreateAccountScreen.tsx
@@ -15,7 +15,7 @@ import { useNavigation } from "@react-navigation/native";
 // ShinyGradientButton — imported *re‑export* so it stays DRY.
 // Move this component into a dedicated `components/Button.tsx` later for cleaner paths.
 // import { ShinyGradientButton } from '../components/ShinyGradientButton';
-import { ShinyGradientButton } from "./WelcomeScreen"; // ✅ temporary path
+import { ShinyGradientButton } from "../../components/ShinyGradientButton";
 // ────────────────────────────────────────────────────────────────────────────────
 
 const CreateAccountScreen: React.FC = () => {

--- a/mobile/screens/onboarding/CreateToonScreen.tsx
+++ b/mobile/screens/onboarding/CreateToonScreen.tsx
@@ -14,7 +14,7 @@ import { Camera, ChevronDown } from "lucide-react-native";
 import { useNavigation } from "@react-navigation/native";
 import { Picker } from "@react-native-picker/picker";
 
-import { ShinyGradientButton } from "./WelcomeScreen";
+import { ShinyGradientButton } from "../../components/ShinyGradientButton";
 
 // ────────────────────────────────────────────────────────────────────────────────
 // Constants

--- a/mobile/screens/onboarding/VerifyCodeScreen.tsx
+++ b/mobile/screens/onboarding/VerifyCodeScreen.tsx
@@ -13,7 +13,7 @@ import { useNavigation, useRoute, RouteProp } from "@react-navigation/native";
 import { RootStackParamList } from "../../App"; // adjust the relative path if App.tsx lives elsewhere
 
 // Re‑use the shiny button we already built
-import { ShinyGradientButton } from "./WelcomeScreen"; // 🔔 move to components/ when you refactor paths
+import { ShinyGradientButton } from "../../components/ShinyGradientButton";
 
 // Type‑safe route params
 type VerifyCodeRouteProp = RouteProp<RootStackParamList, "VerifyCode">;

--- a/mobile/screens/onboarding/WelcomeScreen.tsx
+++ b/mobile/screens/onboarding/WelcomeScreen.tsx
@@ -1,87 +1,15 @@
-import React, { useRef, useEffect } from "react";
+import React from "react";
 import {
   View,
   Text,
   StyleSheet,
   Image,
   Pressable,
-  Animated,
-  Easing,
 } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { useNavigation } from "@react-navigation/native";
+import { ShinyGradientButton } from "../../components/ShinyGradientButton";
 
-// ────────────────────────────────────────────────────────────────────────────────
-// Re-usable shiny gradient button (dimmed & smoother)
-// ────────────────────────────────────────────────────────────────────────────────
-interface ButtonProps {
-  onPress: () => void;
-  children: React.ReactNode;
-}
-
-/**
- * ShinyGradientButton — CTA with a subtle, slow shimmer + press feedback.
- */
-export const ShinyGradientButton: React.FC<ButtonProps> = ({
-  onPress,
-  children,
-}) => {
-  // Animated value that sweeps from 0 ➔ 1 continuously
-  const shimmer = useRef(new Animated.Value(0)).current;
-
-  useEffect(() => {
-    const loop = Animated.loop(
-      Animated.timing(shimmer, {
-        toValue: 1,
-        duration: 4000, // slower sweep
-        easing: Easing.linear,
-        useNativeDriver: true,
-      }),
-      { resetBeforeIteration: true }
-    );
-
-    loop.start();
-    return () => loop.stop();
-  }, [shimmer]);
-
-  // Translate the shimmer bar across ~150% of the button width so the reset is off-screen
-  const translateX = shimmer.interpolate({
-    inputRange: [0, 1],
-    outputRange: [-350, 350],
-  });
-
-  return (
-    <Pressable
-      onPress={onPress}
-      style={({ pressed }) => [
-        styles.buttonWrapper,
-        pressed && { transform: [{ scale: 0.97 }] },
-      ]}
-      android_ripple={{ color: "#ffffff20" }}
-    >
-      <LinearGradient
-        colors={["#00EAFF", "#FF4EE0"]}
-        style={styles.buttonInner}
-      >
-        <Text style={styles.buttonText}>{children}</Text>
-
-        {/* Shimmer overlay – dimmer white and wider bar */}
-        <Animated.View
-          pointerEvents="none"
-          style={[styles.shimmerBar, { transform: [{ translateX }] }]}
-        >
-          <LinearGradient
-            // dimmed highlight
-            colors={["transparent", "rgba(255,255,255,0.25)", "transparent"]}
-            start={{ x: 0, y: 0.5 }}
-            end={{ x: 1, y: 0.5 }}
-            style={{ flex: 1 }}
-          />
-        </Animated.View>
-      </LinearGradient>
-    </Pressable>
-  );
-};
 
 // ────────────────────────────────────────────────────────────────────────────────
 // Lightweight Card stand-in (until you build a proper one or install a UI kit)
@@ -183,26 +111,6 @@ const styles = StyleSheet.create({
     color: "#FFFFFF",
     fontWeight: "600",
     textAlign: "center",
-  },
-  buttonWrapper: {
-    width: "100%",
-    borderRadius: 20,
-    overflow: "hidden",
-    elevation: 4,
-  },
-  buttonInner: {
-    height: 70,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  buttonText: {
-    fontSize: 22,
-    fontWeight: "600",
-    color: "#FFFFFF",
-  },
-  shimmerBar: {
-    ...StyleSheet.absoluteFillObject,
-    width: "200%", // make the bar wider than the button for smoother reset
   },
   loginRow: {
     flexDirection: "row",


### PR DESCRIPTION
## Summary
- extract `ShinyGradientButton` into `mobile/components`
- update imports in all screens to use new component
- clean up `WelcomeScreen` implementation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68530a565e50832fadcd074764bfc514