### PR TITLE
Connect recording to dream processor

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -31,7 +31,7 @@ export type RootStackParamList = {
   CreateToon: undefined;
   Dashboard: undefined;
   Processing: undefined;
-  ComicResult: undefined;
+  ComicResult: { urls: string[] };
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();

--- a/mobile/screens/home/ComicResultScreen.tsx
+++ b/mobile/screens/home/ComicResultScreen.tsx
@@ -9,18 +9,27 @@ import {
   Easing,
 } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
 import { Heart, Share2, Download, X } from "lucide-react-native";
 import { ShinyGradientButton } from "../../components/ShinyGradientButton";
 
-// dummy 6‑panel placeholders (swap uri for your real images)
-const PANELS = [1, 2, 3, 4, 5, 6].map((n) => ({
+interface RouteParams {
+  urls: string[];
+}
+
+// fallback dummy when no urls passed
+const FALLBACK = [1, 2, 3, 4, 5, 6].map((n) => ({
   id: n,
   uri: require("../../assets/image-3.png"),
 }));
 
 export default function ComicResultScreen() {
   const navigation = useNavigation();
+  const route = useRoute();
+  const params = (route.params as RouteParams | undefined) ?? { urls: [] };
+  const PANELS = params.urls.length
+    ? params.urls.map((u, i) => ({ id: i + 1, uri: { uri: u } }))
+    : FALLBACK;
   const [liked, setLiked] = useState(false);
 
   /* floating comic board animation */

--- a/mobile/screens/home/ProcessingScreen.tsx
+++ b/mobile/screens/home/ProcessingScreen.tsx
@@ -60,7 +60,7 @@ export default function ProcessingScreen() {
       );
       if (elapsed >= TOTAL_MS) {
         clearInterval(int);
-        navigation.navigate("ComicResult" as never);
+        navigation.navigate("ComicResult" as never, { urls: [] } as never);
       }
     }, tick);
     return () => clearInterval(int);

--- a/mobile/screens/home/RecordScreen.tsx
+++ b/mobile/screens/home/RecordScreen.tsx
@@ -14,6 +14,7 @@ import { ChevronLeft } from "lucide-react-native";
 import { ShinyGradientButton } from "../../components/ShinyGradientButton";
 import { RootStackParamList } from "../../App";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { PROCESS_DREAM_URL } from "../../config";
 
 /*───────────────────────────────────────────────
   HEADER
@@ -159,10 +160,29 @@ export default function RecordScreen() {
     reset();
     navigation.goBack();
   };
-  const upload = () => {
-    if (uri) {
-      Alert.alert("Pretend", "Would upload here");
-      navigation.navigate("Processing");
+  const upload = async () => {
+    if (!uri) return;
+    try {
+      setStatus("Uploading…");
+      const form = new FormData();
+      form.append("audio", {
+        uri,
+        name: "dream.m4a",
+        type: "audio/m4a",
+      } as any);
+      form.append("user_id", "00000000-0000-0000-0000-000000000000");
+
+      const res = await fetch(PROCESS_DREAM_URL, {
+        method: "POST",
+        body: form,
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const { urls } = await res.json();
+      navigation.navigate("ComicResult", { urls });
+    } catch (e) {
+      console.error(e);
+      Alert.alert("Upload failed", String(e));
+      setStatus("Upload failed");
     }
   };
 

--- a/supabase/functions/process_dream/index.ts
+++ b/supabase/functions/process_dream/index.ts
@@ -192,32 +192,20 @@ serve(async (req) => {
       console.log(`🖼️  Panel ${i + 1} generated`);
     }
 
-    /* 5 — stitch */
-    const stitch = await fetch(
-      `https://${projectRef}.functions.supabase.co/stitch_panels`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
-        },
-        body: JSON.stringify({ urls }),
-      }
-    );
-    if (!stitch.ok) throw new Error(await stitch.text());
-    const { url: composite } = await stitch.json();
-
-    /* 6 — record + respond */
+    /* 5 — record + respond (no stitching) */
     await admin.from("dreams").insert({
       user_id: userId,
       transcript,
       panel_count: sb.panels.length,
       storyboard: sb,
-      composite_url: composite,
+      composite_url: null,
       cost_cents: 5 * sb.panels.length,
     });
 
-    return new Response(composite, { status: 200 });
+    return new Response(JSON.stringify({ urls }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
   } catch (e) {
     console.error(e);
     return new Response(String(e), { status: 500 });


### PR DESCRIPTION
## Summary
- connect `RecordScreen` to backend via `PROCESS_DREAM_URL`
- return image URLs from `process_dream` edge function instead of stitched panel
- pass returned URLs to `ComicResultScreen`
- adjust navigation types and screens accordingly

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npx tsc -p mobile/tsconfig.json --noEmit` *(fails: missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68530fc96044832f9e2378520ec8403b