### PR TITLE
Use dynamic SUPABASE base URL

### DIFF
--- a/mobile/config.ts
+++ b/mobile/config.ts
@@ -2,12 +2,13 @@ export const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL ?? "";
 export const SUPABASE_ANON_KEY =
   process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? "";
 
-const projectRef =
+export const SUPABASE_PROJECT_REF =
   process.env.SUPABASE_PROJECT_REF ??
-  SUPABASE_URL.match(/^https:\/\/([a-z0-9-]+)\.supabase\.co/i)?.[1];
+  SUPABASE_URL.match(/^https:\/\/([a-z0-9-]+)\.supabase\.co/i)?.[1] ??
+  "";
 
-export const FUNCTIONS_BASE_URL = projectRef
-  ? `https://${projectRef}.functions.supabase.co`
+export const FUNCTIONS_BASE_URL = SUPABASE_PROJECT_REF
+  ? `https://${SUPABASE_PROJECT_REF}.functions.supabase.co`
   : "";
 
-export const PROCESS_DREAM_URL = `https://lzrhocmfiulykdxjzaku.functions.supabase.co/process_dream`;
+export const PROCESS_DREAM_URL = `${FUNCTIONS_BASE_URL}/process_dream`;

--- a/mobile/screens/home/DashboardScreen.tsx
+++ b/mobile/screens/home/DashboardScreen.tsx
@@ -14,7 +14,6 @@ import { Home, Book, Settings, X } from "lucide-react-native";
 
 // reuse gradient button from WelcomeScreen (move to components/ later)
 import { ShinyGradientButton } from "../../components/ShinyGradientButton";
-import { PROCESS_DREAM_URL } from "../../config";
 
 const DashboardScreen: React.FC = () => {
   const nav = useNavigation();


### PR DESCRIPTION
## Summary
- derive `FUNCTIONS_BASE_URL` from `SUPABASE_URL` or `SUPABASE_PROJECT_REF`
- compute `PROCESS_DREAM_URL` from `FUNCTIONS_BASE_URL`
- remove unused import in `DashboardScreen`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68545239674c832fb8342a96b8850fd4