### PR TITLE
Wrap logs with DEBUG flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ EXPO_PUBLIC_SUPABASE_URL=
 EXPO_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_PROJECT_REF=
 SUPABASE_SERVICE_ROLE_KEY=
+# Set to "true" to enable debug logging
+DEBUG=
 # Leave these blank until you migrate to Cloudflare Images
 CF_ACCOUNT=
 CF_IMAGES_TOKEN=

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 Turns dreams to reality....
+
+## Debug Logging
+
+Set the `DEBUG` environment variable to `true` to see verbose logs from both the
+Supabase functions and the mobile app. For production deployments leave `DEBUG`
+unset or set it to `false` to silence `console.log` and `console.error`
+messages.

--- a/mobile/screens/home/ComicResultScreen.tsx
+++ b/mobile/screens/home/ComicResultScreen.tsx
@@ -18,6 +18,8 @@ import { ShinyGradientButton } from "../../components/ShinyGradientButton";
 import * as FileSystem from "expo-file-system";
 import * as MediaLibrary from "expo-media-library";
 
+const DEBUG = (process.env.DEBUG ?? "").toLowerCase() === "true";
+
 interface RouteParams {
   urls: string[];
 }
@@ -78,7 +80,7 @@ export default function ComicResultScreen() {
       });
 
       if (result.action === Share.sharedAction) {
-        console.log("Shared successfully");
+        if (DEBUG) console.log("Shared successfully");
       }
     } catch (error) {
       Alert.alert("Error sharing comic", "Failed to share the comic");

--- a/mobile/screens/home/DashboardScreen.tsx
+++ b/mobile/screens/home/DashboardScreen.tsx
@@ -16,6 +16,8 @@ import { Home, Book, Settings, X } from "lucide-react-native";
 import { ShinyGradientButton } from "../../components/ShinyGradientButton";
 import { PROCESS_DREAM_URL } from "../../config";
 
+const DEBUG = (process.env.DEBUG ?? "").toLowerCase() === "true";
+
 const DashboardScreen: React.FC = () => {
   const nav = useNavigation();
   const [isTyping, setIsTyping] = useState(false);
@@ -40,7 +42,7 @@ const DashboardScreen: React.FC = () => {
   };
   const handleDone = () => {
     if (dreamText.trim()) {
-      console.log("Dream text:", dreamText);
+      if (DEBUG) console.log("Dream text:", dreamText);
       // TODO: persist / navigate
     }
     setIsTyping(false);

--- a/mobile/screens/home/RecordScreen.tsx
+++ b/mobile/screens/home/RecordScreen.tsx
@@ -17,6 +17,8 @@ import { RootStackParamList } from "../../App";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { PROCESS_DREAM_URL } from "../../config";
 
+const DEBUG = (process.env.DEBUG ?? "").toLowerCase() === "true";
+
 /*───────────────────────────────────────────────
   HEADER
 ───────────────────────────────────────────────*/
@@ -150,7 +152,7 @@ export default function RecordScreen() {
         ])
       ).start();
     } catch (e) {
-      console.error(e);
+      if (DEBUG) console.error(e);
       setStatus(`Start error: ${(e as Error).message}`);
     }
   };
@@ -167,7 +169,7 @@ export default function RecordScreen() {
       pulseAnim.stopAnimation();
       pulseAnim.setValue(0);
     } catch (e) {
-      console.error(e);
+      if (DEBUG) console.error(e);
       setStatus(`Stop error: ${(e as Error).message}`);
     }
   };
@@ -207,7 +209,7 @@ export default function RecordScreen() {
       const { urls } = await res.json();
       navigation.navigate("ComicResult", { urls });
     } catch (e) {
-      console.error(e);
+      if (DEBUG) console.error(e);
       Alert.alert("Upload failed", String(e));
       setStatus("Upload failed");
     }

--- a/supabase/functions/process_dream/index.ts
+++ b/supabase/functions/process_dream/index.ts
@@ -157,7 +157,8 @@ serve(async (req) => {
       })
       .then((r) => JSON.parse(r.choices[0].message.content!));
 
-    console.log("📜 Storyboard:", JSON.stringify(sb, null, 2));
+    if (DEBUG)
+      console.log("📜 Storyboard:", JSON.stringify(sb, null, 2));
 
     sb.panels = sb.panels.slice(0, MAX_PANELS);
     if (sb.panels.length < MIN_PANELS) {
@@ -170,7 +171,8 @@ serve(async (req) => {
     for (let i = 0; i < sb.panels.length; i++) {
       const prompt = panelPrompt(sb.panels[i], i, SHARED);
 
-      console.log(`🖼️  Panel ${i + 1} (${prompt.length} chars) ⇢ ${prompt}`);
+      if (DEBUG)
+        console.log(`🖼️  Panel ${i + 1} (${prompt.length} chars) ⇢ ${prompt}`);
 
       const res = await fetch("https://api.openai.com/v1/images/generations", {
         method: "POST",
@@ -186,18 +188,19 @@ serve(async (req) => {
 
       if (!res.ok) {
         const errTxt = await res.text();
-        console.error(
-          `❌ Panel ${
-            i + 1
-          } generation failed\nPrompt:\n${prompt}\nRaw error:\n${errTxt}`
-        );
+        if (DEBUG)
+          console.error(
+            `❌ Panel ${
+              i + 1
+            } generation failed\nPrompt:\n${prompt}\nRaw error:\n${errTxt}`
+          );
         urls.push(
           "https://lzrhocmfiulykdxjzaku.supabase.co/storage/v1/object/public/comics/00000000-0000-0000-0000-000000000000/18a6b2c4-b370-435a-b7bb-44d693ce63fb.png"
         );
         continue;
       }
       urls.push((await res.json()).data[0].url as string);
-      console.log(`🖼️  Panel ${i + 1} generated`);
+      if (DEBUG) console.log(`🖼️  Panel ${i + 1} generated`);
     }
 
     /* 5 — record + respond (no stitching) */
@@ -216,7 +219,7 @@ serve(async (req) => {
       headers: { "Content-Type": "application/json" },
     });
   } catch (e) {
-    console.error(e);
+    if (DEBUG) console.error(e);
     return new Response(String(e), { status: 500 });
   }
 });

--- a/supabase/functions/stitch_panels/index.ts
+++ b/supabase/functions/stitch_panels/index.ts
@@ -7,6 +7,7 @@ import {
 } from "https://deno.land/x/canvas@v1.4.1/mod.ts";
 
 const env = Deno.env.toObject();
+const DEBUG = (env.DEBUG ?? "").toLowerCase() === "true";
 const supabase = createClient(
   env.EXPO_PUBLIC_SUPABASE_URL!,
   env.SUPABASE_SERVICE_ROLE_KEY!,
@@ -91,7 +92,7 @@ serve(async (req) => {
       .from("comics")
       .upload(path, finalBuffer, { upsert: true, contentType: "image/png" });
     if (error) {
-      console.error("Upload error:", error);
+      if (DEBUG) console.error("Upload error:", error);
       return new Response(`Upload failed: ${error.message}`, { status: 500 });
     }
 
@@ -102,7 +103,7 @@ serve(async (req) => {
       headers: { "Content-Type": "application/json" },
     });
   } catch (err) {
-    console.error(err);
+    if (DEBUG) console.error(err);
     const msg = err instanceof Error ? err.message : String(err);
     return new Response(`Internal server error: ${msg}`, { status: 500 });
   }


### PR DESCRIPTION
## Summary
- gate `console.log` and `console.error` behind `DEBUG` checks
- add `DEBUG` env variable to sample env file
- document debug flag usage in README

## Testing
- `grep -R "console" -n supabase mobile | head`

------
https://chatgpt.com/codex/tasks/task_e_685452247db0832f88928360a4aff617