### PR TITLE
Return public URLs from process_dream

### DIFF
--- a/mobile/screens/home/ProcessingScreen.tsx
+++ b/mobile/screens/home/ProcessingScreen.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { useNavigation, useRoute } from "@react-navigation/native";
-import { PROCESS_DREAM_URL } from "../../config";
+import { PROCESS_DREAM_URL, SUPABASE_URL } from "../../config";
 import { useSupabaseUserId } from "../../SupabaseContext";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -87,7 +87,12 @@ export default function ProcessingScreen() {
           body: form,
         });
         if (!res.ok) throw new Error(await res.text());
-        const { urls } = await res.json();
+        const data = await res.json();
+        const urls =
+          data.urls ??
+          (data.panel_paths || []).map(
+            (p: string) => `${SUPABASE_URL}/storage/v1/object/public/comics/${p}`
+          );
         setUrls(urls);
         setUploadDone(true);
       } catch (e) {

--- a/mobile/screens/home/RecordScreen.tsx
+++ b/mobile/screens/home/RecordScreen.tsx
@@ -16,7 +16,7 @@ import { useUser } from "../../UserContext";
 import { ShinyGradientButton } from "../../components/ShinyGradientButton";
 import { RootStackParamList } from "../../App";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import { PROCESS_DREAM_URL } from "../../config";
+import { PROCESS_DREAM_URL, SUPABASE_URL } from "../../config";
 import { useSupabaseUserId } from "../../SupabaseContext";
 
 const DEBUG = (process.env.DEBUG ?? "").toLowerCase() === "true";
@@ -212,7 +212,12 @@ export default function RecordScreen() {
         body: form,
       });
       if (!res.ok) throw new Error(await res.text());
-      const { urls } = await res.json();
+      const data = await res.json();
+      const urls =
+        data.urls ??
+        (data.panel_paths || []).map(
+          (p: string) => `${SUPABASE_URL}/storage/v1/object/public/comics/${p}`
+        );
       navigation.navigate("ComicResult", { urls });
     } catch (e) {
       if (DEBUG) console.error(e);

--- a/supabase/functions/process_dream/index.ts
+++ b/supabase/functions/process_dream/index.ts
@@ -262,7 +262,12 @@ for (let i = 0; i < sb.panels.length; i++) {
     });
 
     return new Response(
-      JSON.stringify({ dreamId, panel_paths: paths, composite_path: compositePath }),
+      JSON.stringify({
+        dreamId,
+        panel_paths: paths,
+        urls: pubUrls,
+        composite_path: compositePath,
+      }),
       {
         status: 200,
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- return a `urls` array from `process_dream`
- handle both `urls` and `panel_paths` in Record & Processing screens

## Testing
- `npx tsc --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_6854614b6d84832f9295df1238d7e09b