### PR TITLE
Fix missing seed file error

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -52,10 +52,10 @@ schema_paths = []
 
 [db.seed]
 # If enabled, seeds the database after migrations during a db reset.
-enabled = true
+enabled = false
 # Specifies an ordered list of seed files to load during db reset.
 # Supports glob patterns relative to supabase directory: "./seeds/*.sql"
-sql_paths = ["./seed.sql"]
+sql_paths = []
 
 [realtime]
 enabled = true


### PR DESCRIPTION
## Summary
- disable DB seeding because no seed file exists

## Testing
- `npx supabase db reset` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6854617d7e54832f81a238a484d144c7