### PR TITLE
Configure Firebase auth for Supabase

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -254,8 +254,8 @@ skip_nonce_check = false
 
 # Use Firebase Auth as a third-party provider alongside Supabase Auth.
 [auth.third_party.firebase]
-enabled = false
-# project_id = "my-firebase-project"
+enabled = true
+project_id = "your-firebase-project-id"
 
 # Use Auth0 as a third-party provider alongside Supabase Auth.
 [auth.third_party.auth0]


### PR DESCRIPTION
## Summary
- enable Firebase as a third-party provider in `supabase/config.toml`

## Testing
- `npx supabase start` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6857ebc647d0832f984208f4396b6bf9