### PR TITLE
Add logout helper and hook into settings

### DIFF
--- a/mobile/logout.ts
+++ b/mobile/logout.ts
@@ -1,0 +1,10 @@
+import { supabase } from './supabaseClient';
+import { firebaseAuth } from './firebaseAuth';
+
+/**
+ * Sign out from both Firebase and Supabase.
+ */
+export async function logout() {
+  await firebaseAuth.signOut();
+  await supabase.auth.signOut();
+}

--- a/mobile/screens/home/SettingsScreen.tsx
+++ b/mobile/screens/home/SettingsScreen.tsx
@@ -13,6 +13,7 @@ import {
 } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { useNavigation } from "@react-navigation/native";
+import { logout } from "../../logout";
 import { useUser } from "../../UserContext";
 import {
   Settings as Gear,
@@ -90,7 +91,8 @@ export default function SettingsScreen() {
     setRateModal(false);
   };
   const sendMail = () => Linking.openURL("mailto:support@dreamtoon.com");
-  const confirmLog = () => {
+  const confirmLog = async () => {
+    await logout();
     navigation.reset({ index: 0, routes: [{ name: "Welcome" as never }] });
   };
 


### PR DESCRIPTION
## Summary
- add `logout` helper to sign out from Firebase and Supabase
- use `logout()` when confirming log out from settings

## Testing
- `npx tsc -p mobile` *(fails: Cannot find module 'expo-linear-gradient' or its corresponding type declarations, plus other missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6857ebd32908832fa739fd2278e20139