### PR TITLE
Configure dark mode status bar

### DIFF
--- a/frontend/android/app/src/main/res/values/styles.xml
+++ b/frontend/android/app/src/main/res/values/styles.xml
@@ -2,7 +2,7 @@
   <style name="AppTheme" parent="Theme.EdgeToEdge">
     <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
     <item name="colorPrimary">@color/colorPrimary</item>
-    <item name="android:statusBarColor">#ffffff</item>
+  <item name="android:statusBarColor">#0D0A3C</item>
   </style>
   <style name="Theme.App.SplashScreen" parent="Theme.SplashScreen">
     <item name="windowSplashScreenBackground">@color/splashscreen_background</item>

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/ToonIcon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "dark",
     "scheme": "dreamtoon",
     "ios": {
       "supportsTablet": true,

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -6,6 +6,7 @@ import {
   DefaultTheme,
 } from "@react-navigation/native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
+import { StatusBar } from "react-native";
 
 import LoginScreen from "./(auth)/AuthScreen";
 import WelcomeScreen from "./(auth)/WelcomeScreen";
@@ -30,6 +31,7 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 export default function App() {
   return (
     <SafeAreaProvider>
+      <StatusBar barStyle="light-content" backgroundColor="#0D0A3C" translucent />
       <NavigationIndependentTree>
         <NavigationContainer theme={MyTheme}>
           <Stack.Navigator

--- a/frontend/ios/DreamToon/Info.plist
+++ b/frontend/ios/DreamToon/Info.plist
@@ -65,8 +65,8 @@
 	</array>
 	<key>UIRequiresFullScreen</key>
 	<false/>
-	<key>UIStatusBarStyle</key>
-	<string>UIStatusBarStyleDefault</string>
+        <key>UIStatusBarStyle</key>
+        <string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -79,8 +79,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
+        <key>UIUserInterfaceStyle</key>
+        <string>Dark</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>


### PR DESCRIPTION
## Summary
- set default userInterfaceStyle to dark
- update status bar colors in Android and iOS
- add StatusBar component to React root

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686532c22634832f94e16a43514616db