### PR TITLE
Update error handling

### DIFF
--- a/backend/supabase/functions/process_dream/index.ts
+++ b/backend/supabase/functions/process_dream/index.ts
@@ -284,9 +284,12 @@ serve(async (req) => {
     });
   } catch (e) {
     if (DEBUG) console.error(e);
-    return new Response(JSON.stringify({ error: String(e) }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify({ error: "An unexpected error occurred" }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   }
 });


### PR DESCRIPTION
## Summary
- handle error responses in `process_dream` to avoid leaking stack traces

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run lint` in `frontend` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686538b0fa24832f9667825f78e01a13